### PR TITLE
Fix checkbox selected issue

### DIFF
--- a/dynamicselectableedittext/src/main/java/com/goliathant/dynamicselectableedittext/RVSearchAdapter.java
+++ b/dynamicselectableedittext/src/main/java/com/goliathant/dynamicselectableedittext/RVSearchAdapter.java
@@ -171,7 +171,10 @@ public class RVSearchAdapter extends RecyclerView.Adapter<RVSearchAdapter.RVSear
         @Override
         void bind(Selectable object) {
             cbxItem.setText(object.getLabel());
+            cbxItem.setOnCheckedChangeListener(null);
+            cbxItem.setChecked(object.isSelected());
             cbxItem.setOnCheckedChangeListener((compoundButton, isChecked) -> {
+                object.setSelected(isChecked);
                 if (isChecked) {
                     addSelectedItem(object);
                 } else {

--- a/dynamicselectableedittext/src/main/java/com/goliathant/dynamicselectableedittext/Selectable.java
+++ b/dynamicselectableedittext/src/main/java/com/goliathant/dynamicselectableedittext/Selectable.java
@@ -6,4 +6,6 @@ package com.goliathant.dynamicselectableedittext;
 
 public interface Selectable {
     String getLabel();
+    boolean isSelected();
+    void setSelected(boolean selected);
 }


### PR DESCRIPTION
The problem occurred when checking a checkbox and loading more items. In the loaded items, the one with the same index as the one checked was checked as well.